### PR TITLE
Adding download video action

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Supported Devices:
 How to use:
 - Install the plugin from (https://github.com/mpoulson/Indigo-Ring/archive/0.1.23.zip)
 - Configure username/password
-- Add a new device for each Doorbell
+- Add a new device for each Doorbell or other Ring device
 
 What it does:
-- Updates Devices States on Motion or Ring Events 
+- Updates Device States on Motion or Ring Events 
 - Has separate states for last Motion and Ring event date/time
-- Allows you to download video for the last event on a device (Requires Ring Cloud subscription; NOTE: you must include a short delay of a few minutes after the event triggers in order for the video to become available from Ring before running the Download Video action)
+- Allows you to download video for an event on a device (Requires Ring Cloud subscription; NOTE: you must include a short delay of a few minutes after the event triggers in order for the video to become available from Ring before running the Download Video action)
 
 Sample Use:
 - Create a trigger that fires when a Ring device's lastMotionTime Has Any Change

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ What it does:
 
 Sample Use:
 - Create a trigger that fires when a Ring device's lastMotionTime Has Any Change
-- Fire an action to Download Video for that device's last event after waiting a few minutes by specifying a Delay in Indigo
-- Use another Indigo plugin such as Better Email to send the video as an email attachment to you (note: for this to work, you must also include a Delay on this action to allow time for the file download to complete)
+- Fire an action to Download Video for that device's last event after waiting a few minutes by specifying a delay in the configuration of the action in Indigo
+- Use another Indigo plugin such as Better Email to send the video as an email attachment to you (note: for this to work, you must also include a delay on this action to allow time for the file download to complete)

--- a/README.md
+++ b/README.md
@@ -5,22 +5,27 @@
 The plugin will allow triggers when someone presses the doorbell button or triggers a motion alert, as well as the ability to download video in .mp4 format associated with the event.
 
 Requirements:
-  - A current username/password for your Ring doorbell account
-  - A Ring doorbell (https://www.amazon.com/dp/B00N2ZDXW2/ref=sr_ph_1?ie=UTF8&qid=1482732196&sr=sr-1&keywords=ring)
-  - A Ring Subscription (for downloading video)
+- A current username/password for your Ring doorbell account
+- A Ring doorbell (https://www.amazon.com/dp/B00N2ZDXW2/ref=sr_ph_1?ie=UTF8&qid=1482732196&sr=sr-1&keywords=ring)
+- A Ring Subscription (for downloading video)
 
 Supported Devices:
-  - Ring Doorbell
-  - Ring Doorbell Pro
-  - Ring flood light
-  - Ring Sickup Cam
+- Ring Doorbell
+- Ring Doorbell Pro
+- Ring flood light
+- Ring Sickup Cam
 
 How to use:
-  - Install the plugin from (https://github.com/mpoulson/Indigo-Ring/archive/0.1.23.zip)
-  - Configure username/password
-  - Add a new device for each Doorbell
+- Install the plugin from (https://github.com/mpoulson/Indigo-Ring/archive/0.1.23.zip)
+- Configure username/password
+- Add a new device for each Doorbell
 
 What it does:
-  - Updates Devices States on Motion or Ring Events 
-  - Has separate states for last Motion and Ring event date/time
-  - Allows you to download video for the last event on a device (Requires Ring Cloud subscription; NOTE: you must include a short delay of a few minutes after the event triggers in order for the video to become available from Ring before running the Download Video action)
+- Updates Devices States on Motion or Ring Events 
+- Has separate states for last Motion and Ring event date/time
+- Allows you to download video for the last event on a device (Requires Ring Cloud subscription; NOTE: you must include a short delay of a few minutes after the event triggers in order for the video to become available from Ring before running the Download Video action)
+
+Sample Use:
+- Create a trigger that fires when a Ring device's lastMotionTime Has Any Change
+- Fire an action to Download Video for that device's last event after waiting a few minutes by specifying a Delay in Indigo
+- Use another Indigo plugin such as Better Email to send the video as an email attachment to you (note: for this to work, you must also include a Delay on this action to allow time for the file download to complete)

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ How to use:
 What it does:
   - Updates Devices States on Motion or Ring Events 
   - Has separate states for last Motion and Ring event date/time
-  - Allows you to download for the last event on a device (Requires Ring Cloud subscription)
+  - Allows you to download video for the last event on a device (Requires Ring Cloud subscription; NOTE: you must include a short delay of a few minutes after the event triggers in order for the video to become available from Ring before running the Download Video action)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![N|Solid](http://forums.indigodomo.com/static/www/images/wordmark.png)](http://indigodomo.com)
 
-The plugin will allow triggers when someone presses the doorbell button or triggers a motion alert.
+The plugin will allow triggers when someone presses the doorbell button or triggers a motion alert, as well as the ability to download video in .mp4 format associated with the event.
 
 Requirements:
   - A current username/password for your Ring doorbell account
   - A Ring doorbell (https://www.amazon.com/dp/B00N2ZDXW2/ref=sr_ph_1?ie=UTF8&qid=1482732196&sr=sr-1&keywords=ring)
-  - A Ring Subscription (for recording URL)
+  - A Ring Subscription (for downloading video)
 
 Supported Devices:
   - Ring Doorbell
@@ -23,4 +23,4 @@ How to use:
 What it does:
   - Updates Devices States on Motion or Ring Events 
   - Has separate states for last Motion and Ring event date/time
-  - Will provide URL to recording video of last event (Requires Ring Cloud subscription
+  - Allows you to download for the last event on a device (Requires Ring Cloud subscription)

--- a/Ring.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -17,7 +17,22 @@
 		<CallbackMethod>_setSirenOff</CallbackMethod>
 	</Action>
     <Action id="downloadVideo" deviceFilter="self">
-		<Name>Download Video for Last Event</Name>
+		<Name>Download Video for Specified Event</Name>
 		<CallbackMethod>_downloadVideo</CallbackMethod>
+		<ConfigUI>
+			<Field id="eventIdOption" type="menu" defaultValue="lastEventId"
+				tooltip="Optionally manually specify the Event ID to download video for on this device.">
+				<Label>Event to download video for:</Label>
+				<List>
+					<Option value="lastEventId">Last Event for Device</Option>
+					<Option value="specifyEventId">Specify Event ID Manually</Option>
+				</List>
+			</Field>
+			<Field id="userSpecifiedEventId" type="textfield" visibleBindingId="eventIdOption" visibleBindingValue="specifyEventId"
+				tooltip="Enter the event id to download video for on this deivce">
+				<Label>Event ID (e.g. 5513546390316394328):</Label>
+				<Description>Event ID to download video for on this device</Description>
+			</Field>
+		</ConfigUI>
 	</Action>	
 </Actions>

--- a/Ring.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -20,8 +20,10 @@
 		<Name>Download Video for Specified Event</Name>
 		<CallbackMethod>_downloadVideo</CallbackMethod>
 		<ConfigUI>
-			<Field id="eventIdOption" type="menu" defaultValue="lastEventId"
-				tooltip="Optionally manually specify the Event ID to download video for on this device.">
+			<Field type="textfield" id="downloadFilePath" defaultValue="" tooltip="Path and filename to download video to" visibleBindingValue="true">
+				<Label>Path and filename to download video to (e.g. /Users/yourName/Downloads/ringVideo.mp4):</Label>
+			</Field>
+			<Field id="eventIdOption" type="menu" defaultValue="lastEventId" tooltip="Optionally manually specify the Event ID to download video for on this device.">
 				<Label>Event to download video for:</Label>
 				<List>
 					<Option value="lastEventId">Last Event for Device</Option>

--- a/Ring.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -16,4 +16,8 @@
 		<Name>Turn Siren Off</Name>
 		<CallbackMethod>_setSirenOff</CallbackMethod>
 	</Action>
+    <Action id="downloadVideo" deviceFilter="self">
+		<Name>Download Video for Last Event</Name>
+		<CallbackMethod>_downloadVideo</CallbackMethod>
+	</Action>	
 </Actions>

--- a/Ring.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -30,6 +30,11 @@
 				<TriggerLabel>name</TriggerLabel>
 				<ControlPageLabel>name</ControlPageLabel>
 			</State>
+			<State id="lastEventId">
+				<ValueType>String</ValueType>
+				<TriggerLabel>lastEventId</TriggerLabel>
+				<ControlPageLabel>lastEventId</ControlPageLabel>
+			</State>
 			<State id="lastEvent">
 				<ValueType>String</ValueType>
 				<TriggerLabel>lastEvent</TriggerLabel>
@@ -70,11 +75,6 @@
 				<TriggerLabel>batteryLevel</TriggerLabel>
 				<ControlPageLabel>batteryLevel</ControlPageLabel>
 			</State>
-			<State id="recordingUrl">
-				<ValueType>String</ValueType>
-				<TriggerLabel>RecordingUrl</TriggerLabel>
-				<ControlPageLabel>RecordingUrl</ControlPageLabel>
-			</State>
 		</States>
 	</Device>
 	<Device type="relay" id="RingFloodLight">
@@ -107,6 +107,11 @@
 				<TriggerLabel>name</TriggerLabel>
 				<ControlPageLabel>name</ControlPageLabel>
 			</State>
+			<State id="lastEventId">
+				<ValueType>String</ValueType>
+				<TriggerLabel>lastEventId</TriggerLabel>
+				<ControlPageLabel>lastEventId</ControlPageLabel>
+			</State>
 			<State id="lastEvent">
 				<ValueType>String</ValueType>
 				<TriggerLabel>lastEvent</TriggerLabel>
@@ -136,11 +141,6 @@
 				<ValueType>String</ValueType>
 				<TriggerLabel>firmware</TriggerLabel>
 				<ControlPageLabel>firmware</ControlPageLabel>
-			</State>
-			<State id="recordingUrl">
-				<ValueType>String</ValueType>
-				<TriggerLabel>RecordingUrl</TriggerLabel>
-				<ControlPageLabel>RecordingUrl</ControlPageLabel>
 			</State>
 		</States>
 	</Device>
@@ -174,6 +174,11 @@
 				<ValueType>String</ValueType>
 				<TriggerLabel>name</TriggerLabel>
 				<ControlPageLabel>name</ControlPageLabel>
+			</State>
+			<State id="lastEventId">
+				<ValueType>String</ValueType>
+				<TriggerLabel>lastEventId</TriggerLabel>
+				<ControlPageLabel>lastEventId</ControlPageLabel>
 			</State>
 			<State id="lastEvent">
 				<ValueType>String</ValueType>
@@ -209,11 +214,6 @@
 				<ValueType>Integer</ValueType>
 				<TriggerLabel>Battery Power Level (Percentage)</TriggerLabel>
 				<ControlPageLabel>Battery Power Level (Percentage)</ControlPageLabel>
-			</State>
-			<State id="recordingUrl">
-				<ValueType>String</ValueType>
-				<TriggerLabel>RecordingUrl</TriggerLabel>
-				<ControlPageLabel>RecordingUrl</ControlPageLabel>
 			</State>
 		</States>
 	</Device>

--- a/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -9,6 +9,9 @@
 	<Field type="textfield" id="Password" secure="true" tooltip="Ring Password" visibleBindingValue="true">
 		<Label>Ring Password:</Label>
 	</Field>
+	<Field type="textfield" id="DownloadFilePath" tooltip="Path and filename to download video ro" visibleBindingValue="true">
+		<Label>Path and filename for downloaded video:</Label>
+	</Field>
 	<Field type="textfield" id="maxRetry" tooltip="Max Retries before Failure" defaultValue="5">
 		<Label>Max refresh retry attempts:</Label>
 	</Field>

--- a/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -9,9 +9,6 @@
 	<Field type="textfield" id="Password" secure="true" tooltip="Ring Password" visibleBindingValue="true">
 		<Label>Ring Password:</Label>
 	</Field>
-	<Field type="textfield" id="DownloadFilePath" tooltip="Path and filename to download video ro" visibleBindingValue="true">
-		<Label>Path and filename for downloading video with Download Video action:</Label>
-	</Field>
 	<Field type="textfield" id="maxRetry" tooltip="Max Retries before Failure" defaultValue="5">
 		<Label>Max refresh retry attempts:</Label>
 	</Field>

--- a/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -10,7 +10,7 @@
 		<Label>Ring Password:</Label>
 	</Field>
 	<Field type="textfield" id="DownloadFilePath" tooltip="Path and filename to download video ro" visibleBindingValue="true">
-		<Label>Path and filename for downloaded video:</Label>
+		<Label>Path and filename for downloading video with Download Video action:</Label>
 	</Field>
 	<Field type="textfield" id="maxRetry" tooltip="Max Retries before Failure" defaultValue="5">
 		<Label>Max refresh retry attempts:</Label>

--- a/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/Ring.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -9,6 +9,9 @@
 	<Field type="textfield" id="Password" secure="true" tooltip="Ring Password" visibleBindingValue="true">
 		<Label>Ring Password:</Label>
 	</Field>
+	<Field type="textfield" id="DownloadFilePath" tooltip="Path and filename to download video ro" visibleBindingValue="true">
+		<Label>Path and filename for downloading video with Download Video action:</Label>
+	</Field>
 	<Field type="textfield" id="maxRetry" tooltip="Max Retries before Failure" defaultValue="5">
 		<Label>Max refresh retry attempts:</Label>
 	</Field>

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -9,6 +9,7 @@ import traceback
 import random
 import re
 import time
+import requests # Remove this once meat of _downloadVideo moved to Ring.py
 from datetime import datetime,tzinfo,timedelta
 
 from Ring import Ring
@@ -49,10 +50,12 @@ class Plugin(indigo.PluginBase):
 			if len(lastEvents) == 0:
 				event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
 			else:
-				self.debugLog("Recient Event(s) found!  Count: %s" % len(lastEvents))
+				self.debugLog("Recent Event(s) found!  Count: %s" % len(lastEvents))
 				for k,v in lastEvents.iteritems():
-					event = v
-					break
+					self.debugLog(v)
+					if v.id == doorbellId:
+						event = v
+						break
 
 			if (event == None):
 				#self.debugLog("Failed to get correct event data for deviceID:%s.  Will keep retrying for now.  " % doorbellId)
@@ -75,6 +78,8 @@ class Plugin(indigo.PluginBase):
 			if isNewEvent:
 				try: self.updateStateOnServer(dev, "name", doorbell.description)
 				except: self.de (dev, "name")
+				try: self.updateStateOnServer(dev, "lastEventId", str(event.id))
+				except: self.de (dev, "lastEventId")
 				try: self.updateStateOnServer(dev, "lastEvent", event.kind)
 				except: self.de (dev, "lastEvent")
 				try: self.updateStateOnServer(dev, "lastEventTime", str(event.now))
@@ -88,9 +93,13 @@ class Plugin(indigo.PluginBase):
 				if (doorbell.state is not None):
 					try: dev.updateStateOnServer("onOffState", doorbell.state)
 					except: self.de (dev, "onOffState")
-				if (event.recordingState == "ready"):
-					try: self.updateStateOnServer(dev, "recordingUrl", self.Ring.GetRecordingUrl(event.id))
-					except: self.de (dev, "recordingUrl")
+# Race condition - given we will likely poll and process the event soon after it
+# occurred, good chance the recording won't be ready yet; that, and the requested
+# recordingUrl expires after one hour, so better to just request it only at the
+# time it is needed, i.e. in _downloadVideo			
+#				if (event.recordingState == "ready"):
+#					try: self.updateStateOnServer(dev, "recordingUrl", self.Ring.GetRecordingUrl(event.id))
+#					except: self.de (dev, "recordingUrl")
 				if (event.kind == "motion"):
 					try: self.updateStateOnServer(dev, "lastMotionTime", str(event.now))
 					except: self.de (dev, "lastMotionTime")
@@ -411,3 +420,33 @@ class Plugin(indigo.PluginBase):
 		else:
 			# Else log failure but do NOT update state on Indigo Server.
 			indigo.server.log(u"send Siren \"%s\" %s failed" % (dev.name, "off"), isError=True)
+			
+	def _downloadVideo(self, pluginAction):
+		self.debugLog(u"\t Download video - %s" % pluginAction.pluginTypeId)
+		dev = indigo.devices[pluginAction.deviceId]
+		doorbellId = dev.pluginProps["doorbellId"]
+		
+		filename = '/Users/zodiac/Documents/IndigoLastRingVideo/ringVideo.mp4'
+		
+		# Meat of below should live in Ring.py, not here in plugin.py
+		# Would also be good to check that user has subscription before download attempt
+		try:
+			# Copied headers from Ring.py temporarily until this code is moved in there
+			theHeaders = {'content-type': 'application/json', 'User-Agent': 'ring/3.6.4 (iPhone; iOS 10.2; Scale/2.00)'}
+			url = self.Ring.GetRecordingUrl(dev.states["lastEventId"])
+			response = requests.get(url, headers=theHeaders, verify=False)
+			if response and response.status_code == 200:
+				if filename:
+					with open(filename, 'wb') as recording:
+						recording.write(response.content)
+						indigo.server.log(u"Downloaded video of last event for \"%s\"" % (dev.name))
+						return
+				else:
+					indigo.server.log(u"Missing filename for video download of last event for \"%s\"" % (dev.name), isError=True)
+					return
+			elif response:
+				indigo.server.log(u"Failed to download for \"%s\", response status code was %s" % (dev.name, response.status_code), isError=True)
+			else:
+				indigo.server.log(u"Failed to download for \"%s\", no response for url %s" % (dev.name, url), isError=True)
+		except IOError as error:
+			indigo.server.log(u"%s" % (error), isError=True)

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -46,15 +46,13 @@ class Plugin(indigo.PluginBase):
 
 			lastEvents = Ring.GetDoorbellEvent(self.Ring)
 
-			# Temporary fix to Issue #3 [ZOB]
-			event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
-			#if len(lastEvents) == 0:
-			#	event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
-			#else:
-			#	self.debugLog("Recient Event(s) found!  Count: %s" % len(lastEvents))
-			#	for k,v in lastEvents.iteritems():
-			#		event = v
-			#		break
+			if len(lastEvents) == 0:
+				event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
+			else:
+				self.debugLog("Recient Event(s) found!  Count: %s" % len(lastEvents))
+				for k,v in lastEvents.iteritems():
+					event = v
+					break
 
 			if (event == None):
 				#self.debugLog("Failed to get correct event data for deviceID:%s.  Will keep retrying for now.  " % doorbellId)

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -434,7 +434,16 @@ class Plugin(indigo.PluginBase):
 			if filename:
 				# Copied headers from Ring.py temporarily until this code is moved in there
 				theHeaders = {'content-type': 'application/json', 'User-Agent': 'ring/3.6.4 (iPhone; iOS 10.2; Scale/2.00)'}
-				url = self.Ring.GetRecordingUrl(dev.states["lastEventId"])
+
+				eventId = dev.states["lastEventId"]
+				eventIdOption = pluginAction.props.get('eventIdOption', "lastEventId")
+				if eventIdOption == "specifyEventId":
+					eventId = pluginAction.props.get('userSpecifiedEventId', "")
+				if eventId == "":
+					indigo.server.log(u"No Event ID specified to download for \"%s\"" % (dev.name), isError=True)
+					return
+					
+				url = self.Ring.GetRecordingUrl(eventId)
 				response = requests.get(url, headers=theHeaders, verify=False)
 				if response and response.status_code == 200:
 					with open(filename, 'wb') as recording:

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -46,13 +46,14 @@ class Plugin(indigo.PluginBase):
 
 			lastEvents = Ring.GetDoorbellEvent(self.Ring)
 
-			if len(lastEvents) == 0:
-				event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
-			else:
-				self.debugLog("Recient Event(s) found!  Count: %s" % len(lastEvents))
-				for k,v in lastEvents.iteritems():
-					event = v
-					break
+			event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
+			#if len(lastEvents) == 0:
+			#	event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
+			#else:
+			#	self.debugLog("Recient Event(s) found!  Count: %s" % len(lastEvents))
+			#	for k,v in lastEvents.iteritems():
+			#		event = v
+			#		break
 
 			if (event == None):
 				#self.debugLog("Failed to get correct event data for deviceID:%s.  Will keep retrying for now.  " % doorbellId)

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -46,6 +46,7 @@ class Plugin(indigo.PluginBase):
 
 			lastEvents = Ring.GetDoorbellEvent(self.Ring)
 
+			# Temporary fix to Issue #3 [ZOB]
 			event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
 			#if len(lastEvents) == 0:
 			#	event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -9,7 +9,6 @@ import traceback
 import random
 import re
 import time
-import requests # Remove this once meat of _downloadVideo moved to Ring.py
 from datetime import datetime,tzinfo,timedelta
 
 from Ring import Ring
@@ -50,12 +49,10 @@ class Plugin(indigo.PluginBase):
 			if len(lastEvents) == 0:
 				event = Ring.GetDoorbellEventsforId(self.Ring,doorbellId)
 			else:
-				self.debugLog("Recent Event(s) found!  Count: %s" % len(lastEvents))
+				self.debugLog("Recient Event(s) found!  Count: %s" % len(lastEvents))
 				for k,v in lastEvents.iteritems():
-					self.debugLog(v)
-					if v.id == doorbellId:
-						event = v
-						break
+					event = v
+					break
 
 			if (event == None):
 				#self.debugLog("Failed to get correct event data for deviceID:%s.  Will keep retrying for now.  " % doorbellId)
@@ -78,8 +75,6 @@ class Plugin(indigo.PluginBase):
 			if isNewEvent:
 				try: self.updateStateOnServer(dev, "name", doorbell.description)
 				except: self.de (dev, "name")
-				try: self.updateStateOnServer(dev, "lastEventId", str(event.id))
-				except: self.de (dev, "lastEventId")
 				try: self.updateStateOnServer(dev, "lastEvent", event.kind)
 				except: self.de (dev, "lastEvent")
 				try: self.updateStateOnServer(dev, "lastEventTime", str(event.now))
@@ -93,13 +88,9 @@ class Plugin(indigo.PluginBase):
 				if (doorbell.state is not None):
 					try: dev.updateStateOnServer("onOffState", doorbell.state)
 					except: self.de (dev, "onOffState")
-# Race condition - given we will likely poll and process the event soon after it
-# occurred, good chance the recording won't be ready yet; that, and the requested
-# recordingUrl expires after one hour, so better to just request it only at the
-# time it is needed, i.e. in _downloadVideo			
-#				if (event.recordingState == "ready"):
-#					try: self.updateStateOnServer(dev, "recordingUrl", self.Ring.GetRecordingUrl(event.id))
-#					except: self.de (dev, "recordingUrl")
+				if (event.recordingState == "ready"):
+					try: self.updateStateOnServer(dev, "recordingUrl", self.Ring.GetRecordingUrl(event.id))
+					except: self.de (dev, "recordingUrl")
 				if (event.kind == "motion"):
 					try: self.updateStateOnServer(dev, "lastMotionTime", str(event.now))
 					except: self.de (dev, "lastMotionTime")
@@ -420,33 +411,3 @@ class Plugin(indigo.PluginBase):
 		else:
 			# Else log failure but do NOT update state on Indigo Server.
 			indigo.server.log(u"send Siren \"%s\" %s failed" % (dev.name, "off"), isError=True)
-			
-	def _downloadVideo(self, pluginAction):
-		self.debugLog(u"\t Download video - %s" % pluginAction.pluginTypeId)
-		dev = indigo.devices[pluginAction.deviceId]
-		doorbellId = dev.pluginProps["doorbellId"]
-		
-		filename = self.pluginPrefs["DownloadFilePath"]
-		
-		# Meat of below should live in Ring.py, not here in plugin.py
-		# Would also be good to check that user has subscription before download attempt
-		try:
-			if filename:
-				# Copied headers from Ring.py temporarily until this code is moved in there
-				theHeaders = {'content-type': 'application/json', 'User-Agent': 'ring/3.6.4 (iPhone; iOS 10.2; Scale/2.00)'}
-				url = self.Ring.GetRecordingUrl(dev.states["lastEventId"])
-				response = requests.get(url, headers=theHeaders, verify=False)
-				if response and response.status_code == 200:
-					with open(filename, 'wb') as recording:
-						recording.write(response.content)
-						indigo.server.log(u"Downloaded video of last event for \"%s\"" % (dev.name))
-						return
-				elif response:
-					indigo.server.log(u"Failed to download for \"%s\", response status code was %s" % (dev.name, response.status_code), isError=True)
-				else:
-					indigo.server.log(u"Failed to download for \"%s\", no response for url %s" % (dev.name, url), isError=True)						
-			else:
-				indigo.server.log(u"Missing filename setting in Plugins->Ring Doorbell->Configure... for video download of last event for \"%s\"" % (dev.name), isError=True)
-				return
-		except IOError as error:
-			indigo.server.log(u"%s" % (error), isError=True)

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -431,22 +431,22 @@ class Plugin(indigo.PluginBase):
 		# Meat of below should live in Ring.py, not here in plugin.py
 		# Would also be good to check that user has subscription before download attempt
 		try:
-			# Copied headers from Ring.py temporarily until this code is moved in there
-			theHeaders = {'content-type': 'application/json', 'User-Agent': 'ring/3.6.4 (iPhone; iOS 10.2; Scale/2.00)'}
-			url = self.Ring.GetRecordingUrl(dev.states["lastEventId"])
-			response = requests.get(url, headers=theHeaders, verify=False)
-			if response and response.status_code == 200:
-				if filename:
+			if filename:
+				# Copied headers from Ring.py temporarily until this code is moved in there
+				theHeaders = {'content-type': 'application/json', 'User-Agent': 'ring/3.6.4 (iPhone; iOS 10.2; Scale/2.00)'}
+				url = self.Ring.GetRecordingUrl(dev.states["lastEventId"])
+				response = requests.get(url, headers=theHeaders, verify=False)
+				if response and response.status_code == 200:
 					with open(filename, 'wb') as recording:
 						recording.write(response.content)
 						indigo.server.log(u"Downloaded video of last event for \"%s\"" % (dev.name))
 						return
+				elif response:
+					indigo.server.log(u"Failed to download for \"%s\", response status code was %s" % (dev.name, response.status_code), isError=True)
 				else:
-					indigo.server.log(u"Missing filename for video download of last event for \"%s\"" % (dev.name), isError=True)
-					return
-			elif response:
-				indigo.server.log(u"Failed to download for \"%s\", response status code was %s" % (dev.name, response.status_code), isError=True)
+					indigo.server.log(u"Failed to download for \"%s\", no response for url %s" % (dev.name, url), isError=True)						
 			else:
-				indigo.server.log(u"Failed to download for \"%s\", no response for url %s" % (dev.name, url), isError=True)
+				indigo.server.log(u"Missing filename setting in Plugins->Ring Doorbell->Configure... for video download of last event for \"%s\"" % (dev.name), isError=True)
+				return
 		except IOError as error:
 			indigo.server.log(u"%s" % (error), isError=True)

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -426,7 +426,7 @@ class Plugin(indigo.PluginBase):
 		dev = indigo.devices[pluginAction.deviceId]
 		doorbellId = dev.pluginProps["doorbellId"]
 		
-		filename = self.pluginPrefs["DownloadFilePath"]
+		filename = pluginAction.props.get('downloadFilePath', "")
 		
 		# Meat of below should live in Ring.py, not here in plugin.py
 		# Would also be good to check that user has subscription before download attempt
@@ -448,14 +448,14 @@ class Plugin(indigo.PluginBase):
 				if response and response.status_code == 200:
 					with open(filename, 'wb') as recording:
 						recording.write(response.content)
-						indigo.server.log(u"Downloaded video of last event for \"%s\"" % (dev.name))
+						indigo.server.log(u"Downloaded video of event for \"%s\" to %s" % (dev.name, filename))
 						return
 				elif response:
 					indigo.server.log(u"Failed to download for \"%s\", response status code was %s" % (dev.name, response.status_code), isError=True)
 				else:
 					indigo.server.log(u"Failed to download for \"%s\", no response for url %s" % (dev.name, url), isError=True)						
 			else:
-				indigo.server.log(u"Missing filename setting in Plugins->Ring Doorbell->Configure... for video download of last event for \"%s\"" % (dev.name), isError=True)
+				indigo.server.log(u"Missing filename setting in action settings for video download of event for \"%s\"" % (dev.name), isError=True)
 				return
 		except IOError as error:
 			indigo.server.log(u"%s" % (error), isError=True)

--- a/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ring.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -426,7 +426,7 @@ class Plugin(indigo.PluginBase):
 		dev = indigo.devices[pluginAction.deviceId]
 		doorbellId = dev.pluginProps["doorbellId"]
 		
-		filename = '/Users/zodiac/Documents/IndigoLastRingVideo/ringVideo.mp4'
+		filename = self.pluginPrefs["DownloadFilePath"]
 		
 		# Meat of below should live in Ring.py, not here in plugin.py
 		# Would also be good to check that user has subscription before download attempt


### PR DESCRIPTION
Includes the following changes:
- Adds downloadVideo as an action in Actions.xml, along with an associated filename setting in PluginConfig.xml and an associated _downloadVideo method in plugin.py
- Removes recordingUrl as a custom state for Indigo Ring devices, instead adding a new state: lastEventId; the idea here is that a) recordingUrl expires an hour after being retrieved, so not useful to store and b) we can't retrieve the recordingUrl right when the event is processed anyway, as the timing is such that it is rarely, if ever, ready - instead, we grab the URL on the fly only when specifically triggering a downloadVideo action

Note: one major issue is that if you use the downloadVideo action too soon after an event fires (e.g. a motion), the video won't be ready yet and it will fail.  This currently necessitates a manual delay being inserted by the user in Indigo (e.g. on trigger of lastMotionTime Has Any Change, fire off a downloadVideo action after manual delay of, say, 5 minutes).

Also note:  some of the code I added to plugin.py should really go into Ring.py (as noted in comments), but I don't have access to it to do that.